### PR TITLE
Allow for navigation bar image to be cleared

### DIFF
--- a/Lib/LMStackerWebViewController.m
+++ b/Lib/LMStackerWebViewController.m
@@ -242,6 +242,8 @@ andRootPageTabImageName:(NSString *)pageTabName
     if (self.rootPage) {
         if ([self.delegate rootPageTitleImage] != nil){
             self.navigationItem.titleView = [[UIImageView alloc] initWithImage:[self.delegate rootPageTitleImage]];
+        } else {
+            self.navigationItem.titleView = nil;
         }
     }
 


### PR DESCRIPTION
This works perfect if you have an app that uses an image on a home screen, but needs to clear said image on a replacePage call.