### PR TITLE
Improved webview scrolling deceleration rate

### DIFF
--- a/Lib/LMStackerController.m
+++ b/Lib/LMStackerController.m
@@ -85,6 +85,7 @@
     // Now add a webview to the main controller
     UIWebView *myWebView = [[UIWebView alloc] initWithFrame:myRootController.view.bounds];
     myWebView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    myWebView.scrollView.decelerationRate = UIScrollViewDecelerationRateNormal;
     NSURL *url = [[NSURL alloc]initWithString:browserURL];
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
     [myWebView loadRequest:request];

--- a/Lib/LMStackerWebViewController.m
+++ b/Lib/LMStackerWebViewController.m
@@ -81,6 +81,7 @@ andRootPageTabImageName:(NSString *)pageTabName
     // Setup WebView
     self.myWebView = [[UIWebView alloc] initWithFrame:self.view.bounds];
     self.myWebView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.myWebView.scrollView.decelerationRate = UIScrollViewDecelerationRateNormal;
     [self loadWebView];
 
     // Setup Javascript Bridge


### PR DESCRIPTION
*Problem:* By default, the webview's deceleration rate has much more friction causing the webview's scrolling to feel slower. 

*Fix:* This PR fixes the declaration rate by setting it to `UIScrollViewDecelerationRateNormal`.